### PR TITLE
add a "myschedule" endpoint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,37 @@
+name: test
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: WillAbides/setup-go-faster@v1.11.0
+        with:
+          go-version: ^1.18
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: go mod download -x
+      - run: go vet ./...
+      - uses: dominikh/staticcheck-action@v1.3.0
+        with:
+          install-go: false
+      - run: go test -v ./... -race -bench=. -benchmem -cover -coverprofile cover.out 2>&1 | tee test.out
+      - run: go tool cover -func cover.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.20
+
+# Set destination for COPY
+WORKDIR /app
+
+# Download Go modules
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code. Note the slash at the end, as explained in
+# https://docs.docker.com/engine/reference/builder/#copy
+COPY *.go ./
+ADD internal ./internal
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -o /zenduty-calendar
+
+EXPOSE 3000
+
+# Run
+CMD ["/zenduty-calendar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 
 # Copy the source code. Note the slash at the end, as explained in
 # https://docs.docker.com/engine/reference/builder/#copy
-COPY *.go ./
+COPY *.go *.html ./
 ADD internal ./internal
 
 # Build

--- a/README.md
+++ b/README.md
@@ -1,15 +1,35 @@
 # zenduty-calendar
 
-Exposes a Zenduty schedule as an ICS calendar:
+Exposes a Zenduty schedule as an ICS calendar. Multiple endpoints are possible:
 
 ```
 /calendar/:team/:schedule/:member
 ```
 
+Return the specific zenduty team schedule as an ICS calendar. Only keep events
+where the given member is part of. The ":team" and ":schedule" parts need to be
+UUIDs of the corresponding zenduty team and schedule. The passed ":member" needs
+to be an email address of the zenduty user for whom events should be retained.
+
+```
+/calendar/myschedule
+```
+
+Returns a combined ICS calendar from all zenduty schedules where the logged in
+user (`ZENDUTY_USERNAME` env variable) is part of. Only events for the logged in
+user will be retained.
+
+```
+/calendar/myschedule/:member
+```
+
+Similar to the above endpoint, but the the combined schedule will be created for
+the given ":member" which needs to be an email address of a zenduty user.
+
 ## Configuration
 
 The following environment variables can be configured:
 
-* PORT: Port for the application to listen on
-* ZENDUTY_USERNAME: Zenduty username (ics is only supported with user credentials)
-* ZENDUTY_PASSWORD: Zenduty password
+* `PORT`: Port for the application to listen on
+* `ZENDUTY_USERNAME`: Zenduty username (ics is only supported with user credentials)
+* `ZENDUTY_PASSWORD`: Zenduty password

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ UUIDs of the corresponding zenduty team and schedule. The passed ":member" needs
 to be an email address of the zenduty user for whom events should be retained.
 
 ```
-/calendar/myschedule
+/myschedule
 ```
 
 Returns a combined ICS calendar from all zenduty schedules where the logged in
@@ -20,7 +20,7 @@ user (`ZENDUTY_USERNAME` env variable) is part of. Only events for the logged in
 user will be retained.
 
 ```
-/calendar/myschedule/:member
+/myschedule/:member
 ```
 
 Similar to the above endpoint, but the the combined schedule will be created for

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/arran4/golang-ical v0.1.0
-	github.com/google/uuid v1.3.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/arran4/golang-ical v0.1.0
+	github.com/google/uuid v1.3.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,13 @@ go 1.20
 require (
 	github.com/arran4/golang-ical v0.1.0
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/net v0.15.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
-github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,9 @@ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4d
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -20,6 +22,7 @@ golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqR
 golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
 golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/index.html
+++ b/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>zenduty-calendar</title>
+</head>
+<body>
+	<p>The following endpoints are available</p>
+	<p>
+		<ul>
+			<li>
+				<p>
+					<strong>/myschedule</strong>
+				</p>
+				<p>
+					returns a combined calendar which contains all schedules of all teams
+					where the user identified by the ZIOS_USERNAME env variable is part
+					of. Only events which contain the user as attendee will be kept.
+				</p>
+			</li>
+			<li>
+				<p>
+					<strong>/myschedule/:member</strong>
+				</p>
+				<p>
+					returns a combined calendar which contains all schedules of all teams
+					where the user identified by the ":member" parameter is part of. The
+					":member" parameter needs to be an email address identifying the member.
+					Only events which contain the member as attendee will be kept.
+				</p>
+			</li>
+			<li>
+				<p>
+					<strong>/calendar/:team/:schedule/:member</strong>
+				</p>
+				<p>
+					returns a specific schedule identified by the given ":team" and ":schedule:
+					parameters. They need to be the zenduty UUIDs identyfing the corresponding team
+					and schedule. Only events attended by the given ":member" parameter will be
+					kept. The ":member" parameter needs to be an email address identifying the
+					zenduty user.
+				</p>
+			</li>
+		</ul>
+	</p>
+</body>
+</html>

--- a/internal/zenduty/zenduty.go
+++ b/internal/zenduty/zenduty.go
@@ -147,7 +147,7 @@ func (c *Client) do(req *http.Request, obj interface{}) error {
 		break
 	}
 
-	c.logger.Info("request", "req", req)
+	c.logger.Debug("request", "req", req)
 	res, err := c.http.Do(req)
 	if err != nil {
 		return err

--- a/internal/zenduty/zenduty.go
+++ b/internal/zenduty/zenduty.go
@@ -8,15 +8,24 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"os"
+	"strings"
+	"time"
 
+	ics "github.com/arran4/golang-ical"
 	"golang.org/x/exp/slog"
 	"golang.org/x/net/publicsuffix"
 )
 
+const (
+	defaultTimeout = 5 * time.Second
+	amountMonths   = 12
+)
+
 type Client struct {
-	BaseURL    *url.URL
-	HTTPCLient *http.Client
-	Logger     *slog.Logger
+	http    *http.Client
+	baseURL *url.URL
+	logger  *slog.Logger
 }
 
 type loginRequest struct {
@@ -32,17 +41,73 @@ type scheduleICSResponse struct {
 	URL string `json:"url"`
 }
 
+func defaultBaseURL() *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   "www.zenduty.com",
+	}
+}
+
+func defaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: defaultTimeout,
+	}
+}
+
+type LoggerOptions struct {
+	slog.HandlerOptions
+	Out io.Writer
+}
+
+// NewLogger returns a new logger instance which logs to the given output
+func NewLogger(options LoggerOptions) *slog.Logger {
+	var output io.Writer = os.Stdout
+	if options.Out != nil {
+		output = options.Out
+	}
+	return slog.New(slog.NewTextHandler(output, &options.HandlerOptions)).With("pkg", "zenduty")
+}
+
+func NewClient(opts ...ClientOption) *Client {
+	c := &Client{
+		baseURL: defaultBaseURL(),
+		http:    defaultHTTPClient(),
+		logger:  NewLogger(LoggerOptions{}),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+type ClientOption func(c *Client)
+
+// BaseURL sets the base URL of the zenduty client
+func BaseURL(u *url.URL) ClientOption {
+	return func(c *Client) {
+		c.baseURL = u
+	}
+}
+
+// Logger sets the logger of the zenduty client
+func Logger(logger *slog.Logger) ClientOption {
+	return func(c *Client) {
+		c.logger = logger
+	}
+}
+
+// Login executes a login with the given username and password
 func (c *Client) Login(username, password string) error {
-	if c.HTTPCLient.Jar == nil {
+	if c.http.Jar == nil {
 		jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 		if err != nil {
 			return fmt.Errorf("jar init error: %w", err)
 		}
 
-		c.HTTPCLient.Jar = jar
+		c.http.Jar = jar
 	}
 
-	res, err := c.HTTPCLient.Get(fmt.Sprintf("%s/login/", c.BaseURL))
+	res, err := c.http.Get(fmt.Sprintf("%s/login/", c.baseURL))
 	if err != nil {
 		return fmt.Errorf("error getting login page: %w", err)
 	}
@@ -51,75 +116,213 @@ func (c *Client) Login(username, password string) error {
 	}
 
 	body := new(bytes.Buffer)
-	json.NewEncoder(body).Encode(loginRequest{Email: username, Password: password})
+	if err := json.NewEncoder(body).Encode(loginRequest{Email: username, Password: password}); err != nil {
+		return fmt.Errorf("can not encode login body: %w", err)
+	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/account/loginAjax/", c.BaseURL), body)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/api/account/loginAjax/", c.baseURL), body)
 	if err != nil {
 		return fmt.Errorf("error creating login request: %w", err)
 	}
-	req.Header.Set("content-type", "application/json")
-
-	c.Logger.Info("request", "req", req)
-
-	res, err = c.do(req)
-	if err != nil {
-		return fmt.Errorf("error logging in: %w", err)
-	}
-	if res.StatusCode < 200 || res.StatusCode > 299 {
-		return fmt.Errorf("error logging in")
-	}
-
-	var respBody loginResponse
-	err = json.NewDecoder(res.Body).Decode(&respBody)
-	if err != nil {
+	resp := &loginResponse{}
+	if err = c.do(req, resp); err != nil {
 		return fmt.Errorf("error logging in: %w", err)
 	}
 
-	c.Logger.Info("cookies", "jar", c.HTTPCLient.Jar)
-
+	c.logger.Info("cookies", "jar", c.http.Jar)
 	return nil
 }
 
-func (c *Client) do(req *http.Request) (*http.Response, error) {
-	cookies := c.HTTPCLient.Jar.Cookies(c.BaseURL)
+func (c *Client) do(req *http.Request, obj interface{}) error {
+	req.Header.Set("content-type", "application/json")
+	cookies := c.http.Jar.Cookies(c.baseURL)
 	for _, cookie := range cookies {
 		if cookie.Name != "csrftoken" {
 			continue
 		}
-
 		req.Header.Set("X-CSRFToken", cookie.Value)
 		break
 	}
 
-	return c.HTTPCLient.Do(req)
-}
-
-func (c *Client) GetSchedule(teamID, scheduleID string, months int) (io.ReadCloser, error) {
-	url := fmt.Sprintf("%s/api/account/teams/%s/schedules/%s/get_schedule_ics/?months=%d&is_team_or_user=1", c.BaseURL, teamID, scheduleID, months)
-	req, err := http.NewRequest("GET", url, nil)
+	c.logger.Info("request", "req", req)
+	res, err := c.http.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error creating request schedule %s, team %s: %w", scheduleID, teamID, err)
-	}
-	req.Header.Set("content-type", "application/json")
-
-	res, err := c.HTTPCLient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error requesting schedule %s, team %s: %w", scheduleID, teamID, err)
+		return err
 	}
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		return nil, fmt.Errorf("error requesting schedule %s, team %s: status: %s", scheduleID, teamID, res.Status)
+		return fmt.Errorf("received error code %d from server", res.StatusCode)
 	}
+	if obj == nil {
+		return nil
+	}
+	return json.NewDecoder(res.Body).Decode(obj)
+}
 
-	var body scheduleICSResponse
-	err = json.NewDecoder(res.Body).Decode(&body)
+type team struct {
+	ID      string          `json:"unique_id"`
+	Name    string          `json:"name"`
+	Account string          `json:"account"`
+	Members []apiTeamMember `json:"members"`
+}
+
+func (t team) containsUser(email string) bool {
+	for _, member := range t.Members {
+		if member.User.Email == email {
+			return true
+		}
+	}
+	return false
+}
+
+type teamList []team
+
+func (tl teamList) teamsForUser(email string) teamList {
+	result := []team{}
+	for _, team := range tl {
+		if team.containsUser(email) {
+			result = append(result, team)
+		}
+	}
+	return result
+}
+
+type apiUser struct {
+	ID        string `json:"username"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Email     string `json:"email"`
+}
+
+type apiTeamMember struct {
+	ID          string    `json:"unique_id"`
+	User        apiUser   `json:"user"`
+	JoiningDate time.Time `json:"joining_date"`
+}
+
+type apiSchedule struct {
+	ID          string `json:"unique_id"`
+	Name        string `json:"name"`
+	Summary     string `json:"summary"`
+	Description string `json:"description"`
+}
+
+// Schedule wraps a calendar to provide additional functions
+type Schedule struct {
+	*ics.Calendar
+}
+
+// Filter filters the schedule based on the given property and value function
+func (s *Schedule) filter(prop ics.ComponentProperty, valueFilter func(value string) bool) *Schedule {
+	out := *s
+	out.Components = []ics.Component{}
+
+	for _, event := range s.Events() {
+		if valueFilter(event.GetProperty(prop).Value) {
+			out.AddVEvent(event)
+		}
+	}
+	return &out
+}
+
+// OnlyAttendees keeps only the events where at least one of the given emails
+// is an attendee
+func (s *Schedule) OnlyAttendees(emails ...string) *Schedule {
+	return s.filter(
+		ics.ComponentPropertyAttendee,
+		func(value string) bool {
+			for _, email := range emails {
+				if strings.Contains(value, email) {
+					return true
+				}
+			}
+			return false
+		},
+	)
+}
+
+func newScheduleFrom(data io.Reader) (*Schedule, error) {
+	cal, err := ics.ParseCalendar(data)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding url for schedule %s, team %s: %w", scheduleID, teamID, err)
+		return nil, fmt.Errorf("got error when parsing calendar: %w", err)
 	}
+	return &Schedule{Calendar: cal}, nil
+}
 
-	res, err = c.HTTPCLient.Get(body.URL)
+func (c *Client) listTeams() (teamList, error) {
+	url := fmt.Sprintf("%s/api/account/teams", c.baseURL)
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error requesting ics for schedule %s, team %s: %w", scheduleID, teamID, err)
+		return nil, fmt.Errorf("can't create request to list teams: %w", err)
+	}
+	teamsResp := []team{}
+	if err := c.do(req, &teamsResp); err != nil {
+		return nil, fmt.Errorf("can't list teams: %w", err)
+	}
+	return teamsResp, nil
+}
+
+func (c *Client) listSchedules(teamID string) ([]apiSchedule, error) {
+	url := fmt.Sprintf("%s/api/account/teams/%s/schedules", c.baseURL, teamID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for listing team schedules: %w", err)
 	}
 
-	return res.Body, err
+	scheduleList := []apiSchedule{}
+	if err := c.do(req, &scheduleList); err != nil {
+		return nil, fmt.Errorf("error when listing schedules of team with ID %s: %w", teamID, err)
+	}
+	return scheduleList, nil
+}
+
+// CombinedSchedule returns the full combined schedule of all team schedules where the given
+// user email is part of
+func (c *Client) CombinedSchedule(email string) (*Schedule, error) {
+	teams, err := c.listTeams()
+	if err != nil {
+		return nil, err
+	}
+	teamsOfUser := teams.teamsForUser(email)
+	combined := ics.NewCalendarFor("zenduty-oncall")
+	for _, team := range teamsOfUser {
+		schedules, err := c.listSchedules(team.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, schedule := range schedules {
+			calendar, err := c.GetSchedule(team.ID, schedule.ID, amountMonths)
+			if err != nil {
+				return nil, err
+			}
+			c.logger.Debug("got calendar response", "content", string(calendar.Serialize()))
+			for _, event := range calendar.Events() {
+				event := event
+				if event == nil {
+					continue
+				}
+				msg := fmt.Sprintf("on call for team %s", team.Name)
+				event.SetSummary(msg)
+				event.SetDescription(fmt.Sprintf("%s (schedule: %s)", msg, schedule.Name))
+				combined.AddVEvent(event)
+			}
+		}
+	}
+	return &Schedule{Calendar: combined}, nil
+}
+
+func (c *Client) GetSchedule(teamID, scheduleID string, months int) (*Schedule, error) {
+	url := fmt.Sprintf("%s/api/account/teams/%s/schedules/%s/get_schedule_ics/?months=%d&is_team_or_user=1", c.baseURL, teamID, scheduleID, months)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request schedule %q of team %q: %w", scheduleID, teamID, err)
+	}
+	body := scheduleICSResponse{}
+	if err := c.do(req, &body); err != nil {
+		return nil, fmt.Errorf("error requesting schedule %q of team %q: %w", scheduleID, teamID, err)
+	}
+	res, err := c.http.Get(body.URL)
+	if err != nil {
+		return nil, fmt.Errorf("error requesting ics for schedule %q of team %q: %w", scheduleID, teamID, err)
+	}
+	return newScheduleFrom(res.Body)
 }

--- a/internal/zenduty/zenduty_test.go
+++ b/internal/zenduty/zenduty_test.go
@@ -3,7 +3,9 @@ package zenduty
 import (
 	"os"
 	"testing"
+	"time"
 
+	ics "github.com/arran4/golang-ical"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slog"
 )
@@ -25,6 +27,118 @@ func TestICS(t *testing.T) {
 
 	calendar, err := z.CombinedSchedule(username)
 	require.NoError(t, err)
+	calendar = calendar.OnlyAttendees(username)
 	require.True(t, len(calendar.Events()) > 0)
 	logger.Debug("my schedule", "content", calendar.Serialize())
+}
+
+func TestOnlyAttendees(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		schedule    *Schedule
+		emails      []string
+		expectedIDs []string
+	}{
+		"filter single email": {
+			schedule: newTestSchedule(
+				[]event{
+					{
+						id:        "one",
+						startTime: time.Now(),
+						summary:   "event1",
+						attendeeEmails: []string{
+							"user1@example.com",
+						},
+					},
+					{
+						id:        "two",
+						startTime: time.Now(),
+						summary:   "event2",
+						attendeeEmails: []string{
+							"user1@example.com",
+							"user2@example.com",
+						},
+					},
+					{
+						id:        "three",
+						startTime: time.Now(),
+						summary:   "event3",
+						attendeeEmails: []string{
+							"user3@example.com",
+						},
+					},
+				},
+			),
+			emails:      []string{"user1@example.com"},
+			expectedIDs: []string{"one", "two"},
+		},
+		"filter multiple emails": {
+			schedule: newTestSchedule(
+				[]event{
+					{
+						id:        "one",
+						startTime: time.Now(),
+						summary:   "event1",
+						attendeeEmails: []string{
+							"user1@example.com",
+						},
+					},
+					{
+						id:        "two",
+						startTime: time.Now(),
+						summary:   "event2",
+						attendeeEmails: []string{
+							"user1@example.com",
+							"user2@example.com",
+						},
+					},
+					{
+						id:        "three",
+						startTime: time.Now(),
+						summary:   "event3",
+						attendeeEmails: []string{
+							"user3@example.com",
+						},
+					},
+				},
+			),
+			emails:      []string{"user1@example.com", "user3@example.com"},
+			expectedIDs: []string{"one", "two", "three"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			testCase := testCase
+			schedule := testCase.schedule.OnlyAttendees(testCase.emails...)
+			require.Len(t, schedule.Events(), len(testCase.expectedIDs))
+			for _, id := range testCase.expectedIDs {
+				require.True(t, schedule.ContainsEventID(id), "did not find ID %s in events", id)
+			}
+		})
+	}
+}
+
+type event struct {
+	id             string
+	summary        string
+	description    string
+	startTime      time.Time
+	attendeeEmails []string
+}
+
+func newTestSchedule(events []event) *Schedule {
+	schedule := ics.NewCalendarFor("test")
+	for _, event := range events {
+		added := schedule.AddEvent(event.id)
+		added.SetStartAt(event.startTime)
+		added.SetEndAt(event.startTime.Add(24 * time.Hour))
+		added.SetSummary(event.summary)
+		desc := event.description
+		if desc == "" {
+			desc = event.summary
+		}
+		added.SetDescription(desc)
+		for _, email := range event.attendeeEmails {
+			added.AddAttendee(email)
+		}
+	}
+	return &Schedule{Calendar: schedule}
 }

--- a/internal/zenduty/zenduty_test.go
+++ b/internal/zenduty/zenduty_test.go
@@ -1,0 +1,30 @@
+package zenduty
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slog"
+)
+
+func TestICS(t *testing.T) {
+	username, password := os.Getenv("ZENDUTY_USERNAME"), os.Getenv("ZENDUTY_PASSWORD")
+	if username == "" || password == "" {
+		t.Skip("no ZENDUTY_USERNAME or ZENDUTY_PASSWORD env variable set")
+	}
+
+	options := LoggerOptions{}
+	options.Level = slog.LevelInfo
+	// use the debug level to see the downloaded calendars and the combined
+	// one
+	// options.Level = slog.LevelDebug
+	logger := NewLogger(options)
+	z := NewClient(Logger(logger))
+	require.NoError(t, z.Login(username, password))
+
+	calendar, err := z.CombinedSchedule(username)
+	require.NoError(t, err)
+	require.True(t, len(calendar.Events()) > 0)
+	logger.Debug("my schedule", "content", calendar.Serialize())
+}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ func run(out io.Writer) error {
 	router := httprouter.New()
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.Header().Set("content-type", "text/text; charset=utf-8")
+		fmt.Fprint(w, "/calendar/myschedule")
+		fmt.Fprint(w, "/calendar/myschedule/:member")
 		fmt.Fprint(w, "/calendar/:team/:schedule/:member")
 	})
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"golang.org/x/exp/slog"
 
+	_ "embed"
+
 	"github.com/thde/zenduty-calendar/internal/zenduty"
 )
 
@@ -17,6 +19,9 @@ var (
 	username = os.Getenv("ZENDUTY_USERNAME")
 	password = os.Getenv("ZENDUTY_PASSWORD")
 	port     = os.Getenv("PORT")
+
+	//go:embed index.html
+	index string
 )
 
 func run(out io.Writer) error {
@@ -34,23 +39,21 @@ func run(out io.Writer) error {
 
 	router := httprouter.New()
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		w.Header().Set("content-type", "text/text; charset=utf-8")
-		fmt.Fprint(w, "/myschedule")
-		fmt.Fprint(w, "/myschedule/:member")
-		fmt.Fprint(w, "/calendar/:team/:schedule/:member")
+		w.Header().Set("content-type", "text/html; charset=utf-8")
+		fmt.Fprint(w, index)
 	})
 
-	// return a specific schedule identified by the given team and schedule
+	// returns a specific schedule identified by the given team and schedule
 	// UUID. Only events attended by the given member (needs to be an email
 	// address) will be kept.
 	router.GET("/calendar/:team/:schedule/:member", byAtendeeHandler("team", "schedule", "member", z.GetSchedule))
 
-	// return a combined calendar which contains all schedules of all teams
+	// returns a combined calendar which contains all schedules of all teams
 	// where the user identified by the ZIOS_USERNAME env variable is part
 	// of. Only events which contain the user as attendee will be kept.
 	router.GET("/myschedule", myScheduleHandler(z, func(_ httprouter.Params) string { return username }))
 
-	// return a combined calendar which contains all schedules of all teams
+	// returns a combined calendar which contains all schedules of all teams
 	// where the user identified by the "member" parameter (needs to be an
 	// email address) is part of. Only events which contain that user as
 	// attendee will be kept.

--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ func run(out io.Writer) error {
 	router := httprouter.New()
 	router.GET("/", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		w.Header().Set("content-type", "text/text; charset=utf-8")
-		fmt.Fprint(w, "/calendar/myschedule")
-		fmt.Fprint(w, "/calendar/myschedule/:member")
+		fmt.Fprint(w, "/myschedule")
+		fmt.Fprint(w, "/myschedule/:member")
 		fmt.Fprint(w, "/calendar/:team/:schedule/:member")
 	})
 
@@ -48,13 +48,13 @@ func run(out io.Writer) error {
 	// return a combined calendar which contains all schedules of all teams
 	// where the user identified by the ZIOS_USERNAME env variable is part
 	// of. Only events which contain the user as attendee will be kept.
-	router.GET("/calendar/myschedule", myScheduleHandler(z, func(_ httprouter.Params) string { return username }))
+	router.GET("/myschedule", myScheduleHandler(z, func(_ httprouter.Params) string { return username }))
 
 	// return a combined calendar which contains all schedules of all teams
 	// where the user identified by the "member" parameter (needs to be an
 	// email address) is part of. Only events which contain that user as
 	// attendee will be kept.
-	router.GET("/calendar/myschedule/:member", myScheduleHandler(z, func(ps httprouter.Params) string { return ps.ByName("member") }))
+	router.GET("/myschedule/:member", myScheduleHandler(z, func(ps httprouter.Params) string { return ps.ByName("member") }))
 
 	server := http.Server{
 		Addr:         fmt.Sprintf(":%v", port),


### PR DESCRIPTION
This adds a "/myschedule" endpoint which exports a calendar consisting of all events from all team schedules the logged in user (identified by the `ZENDUTY_USERNAME` env variable) is part of.